### PR TITLE
fix: icons alignement in object config

### DIFF
--- a/desktop/php/object.php
+++ b/desktop/php/object.php
@@ -252,7 +252,9 @@ $synthToActions = array(
 							</div>
 							<div class="form-group">
 								<label class="col-sm-3 control-label checkbox-inline">{{Couleurs personnalisées}}</label>
-								<input class="objectAttr" type="checkbox" data-l1key="configuration" data-l2key="useCustomColor" />
+								<div class="col-sm-7">
+									<input class="objectAttr" type="checkbox" data-l1key="configuration" data-l2key="useCustomColor">
+								</div>
 							</div>
 							<div class="form-group">
 								<label class="col-sm-3 control-label">{{Couleur du tag}}
@@ -298,7 +300,9 @@ $synthToActions = array(
 							</div>
 							<div class="form-group">
 								<label class="col-sm-3 control-label checkbox-inline">{{Réordonner automatiquement}}</label>
-								<input type="checkbox" class="objectAttr" data-l1key="configuration" data-l2key="orderEqLogicByUsage::auto" />
+								<div class="col-sm-7">
+									<input type="checkbox" class="objectAttr" data-l1key="configuration" data-l2key="orderEqLogicByUsage::auto" />
+								</div>
 							</div>
 						</div>
 


### PR DESCRIPTION
## Proposed change
As per request here:
https://community.jeedom.com/t/core-v4-4-alpha-alignement-case-a-cocher-dans-la-configuration-des-objets/116652

## Type of change
- [ ] 3rd party lib update
- [x] Bugfix (non breaking change)
- [ ] Core new feature
- [ ] UI new functionnality
- [x] Code quality improvements
- [ ] Core documentation

## Test check
Before:
![image](https://github.com/BadWolf42/core/assets/8396512/d760c25b-9086-4c31-8a08-767bbe80b691)

After:
![image](https://github.com/BadWolf42/core/assets/8396512/0e637677-f2a5-49fc-82dd-389cceb0a938)
